### PR TITLE
Add support for %VAR% syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,6 +66,7 @@ name = "batch-compiler"
 version = "0.0.0"
 dependencies = [
  "clap",
+ "regex",
  "sha2",
  "which",
 ]
@@ -208,6 +218,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +246,35 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4.5.40", features = ["derive"] }
+regex = "1.11.1"
 sha2 = "0.10.9"
 which = "8.0.0"

--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,10 @@ test2:
 	clear
 	batch-compiler -o test.exe -i examples\labels.bat
 
+test3:
+	cargo install --path .
+	clear
+	batch-compiler -o test.exe -i examples\vars.bat
+
 clean:
 	cargo clean

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # benja2998/batch
 
-Batch compiler written in Rust
+Batch compiler written in [Rust](https://rust-lang.org)
 
 ## Usage
 
@@ -20,17 +20,17 @@ make run ARGS="-h" # or "batch-compiler -h"
 You can also try some of the tests:
 
 ```bash
-make test<num> # where <num> is the test number
+make test<num> # where <num> is the test number. Currently, there are only 3 tests
 ```
 
 ## Limitations
 
 * If the batch file has no `exit` commands that are **always** executed, it may lead to undefined behavior in the compiled binary.
-* Many batch features are not supported, such as variaables, `if` statements, `for` loops, etc.
+* Many batch features are not supported, such as `if` statements, `for` loops, delayed variable expansion, etc.
 
 ## Features
 
-* Significantly faster than the `cmd.exe` interpreter
+* Significantly faster than the Windows `cmd.exe` interpreter
 
 ## Currently supported batch features
 
@@ -39,6 +39,8 @@ make test<num> # where <num> is the test number
 * Labels
 * Goto command
 * Comments (`rem` or `::`)
+* Set command
+* %VAR% variable syntax
 
 ## Supported OSes
 
@@ -48,10 +50,10 @@ make test<num> # where <num> is the test number
 
 ### Compiled batch files
 
-* All "Modern" versions of Windows (Windows Vista and later, but only tested on Windows 11)
-* Linux via Wine (no official support, untested)
-* Android via Termux & [Box64Droid](https://github.com/Ilya114/Box64Droid) (no official support, untested)
-* macOS via Wine (no official support, untested)
+* All "Modern" versions of [Windows](https://windows.com) ([Windows Vista](https://en.wikipedia.org/wiki/Windows_Vista) and later, but only tested on [Windows 11](https://www.microsoft.com/en-gb/windows/get-windows-11))
+* [Linux](https://en.wikipedia.org/wiki/Linux) via [Wine](https://winehq.org) (no official support, untested)
+* [Android](https://android.com) via Termux & [Box64Droid](https://github.com/Ilya114/Box64Droid) (no official support, untested)
+* [macOS](https://apple.com/macos) via [Wine](https://winehq.org) (no official support, untested)
 
 ## License
 
@@ -77,4 +79,4 @@ A: See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 **Q: What is batch?**
 
-A: Batch is a Windows scripting language developed by Microsoft. It is used in .cmd files, .bat files and the Windows command prompt.
+A: [Batch](https://en.wikipedia.org/wiki/Batch_file) is a [Windows](https://windows.com) scripting language developed by [Microsoft](https://microsoft.com). It is used in .cmd files, .bat files and the [Windows command prompt](https://en.wikipedia.org/wiki/Cmd.exe).

--- a/examples/vars.bat
+++ b/examples/vars.bat
@@ -1,0 +1,19 @@
+@echo off
+
+goto main
+
+:main
+
+set foo=1
+goto main3
+
+:main2
+
+set foo=2
+echo %foo%
+exit /b 0
+
+:main3
+
+set foo=3
+goto main2

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -99,8 +99,24 @@ pub fn compile(statements: &[Statement], output_filename: &str, input_filename: 
                 println!("New line");
             }
 
-            Statement::EchoNewLine { value, invisible, redirection } => {
+            Statement::EchoNewLine {
+                value,
+                invisible,
+                redirection,
+            } => {
                 println!("Echo new line");
+            }
+
+            Statement::Set {
+                variable,
+                value,
+                invisible,
+            } => {
+                println!("Set variable: {}", variable.join(" "));
+                println!("Value: {}", value);
+
+                // Set is handled in expand_vars.rs before compilation
+                // This is because batch works by expanding variables
             }
 
             stmt => {
@@ -289,6 +305,18 @@ fn compile_phase_2(statements: &[Statement], output_filename: &str)
                 // Translate it to a ;
                 println!("Rem: {}", comment);
                 writeln!(asm_file, "; {}", comment).unwrap();
+            }
+
+            Statement::Set {
+                variable,
+                value,
+                invisible,
+            } => {
+                println!("Set variable: {}", variable.join(" "));
+                println!("Value: {}", value);
+
+                // Set is handled in expand_vars.rs before compilation
+                // This is because batch works by expanding variables
             }
 
             Statement::NewLine => {

--- a/src/expand_vars.rs
+++ b/src/expand_vars.rs
@@ -1,0 +1,73 @@
+use std::collections::{HashMap, VecDeque};
+use std::io::Write;
+
+use crate::parse::Statement;
+
+// Expand variables in statements by simulating label-based control flow.
+pub fn expand_vars(input_file: &str, statements: &mut [Statement])
+{
+    // Step 1: Map labels to indices
+    let mut label_map = HashMap::new();
+    for (i, stmt) in statements.iter().enumerate() {
+        if let Statement::Label(name) = stmt {
+            label_map.insert(name.clone(), i);
+        }
+    }
+
+    // Step 2: Set up the execution queue
+    let mut queue = VecDeque::new();
+    let mut visited = HashMap::new();
+    queue.push_back((0, HashMap::new())); // start at statement 0 with empty vars
+
+    while let Some((mut idx, mut vars)) = queue.pop_front() {
+        while idx < statements.len() {
+            match &mut statements[idx] {
+                Statement::Set {
+                    variable, value, ..
+                } => {
+                    if let Some(var_name) = variable.first() {
+                        vars.insert(var_name.clone(), value.clone());
+                    }
+                    idx += 1;
+                }
+
+                Statement::Echo { value, .. } | Statement::EchoNewLine { value, .. } => {
+                    for val in value.iter_mut() {
+                        *val = expand_string(val, &vars);
+                    }
+                    idx += 1;
+                }
+
+                Statement::Goto { label, .. } => {
+                    if let Some(&target_idx) = label_map.get(label) {
+                        queue.push_back((target_idx, vars.clone()));
+                    }
+                    break; // Stop current linear flow
+                }
+
+                Statement::Exit { .. } => break,
+
+                Statement::Label(name) => {
+                    let var_snapshot = visited.entry(name.clone()).or_insert(Vec::new());
+                    if var_snapshot.contains(&vars) {
+                        break; // already visited this label with same vars
+                    }
+                    var_snapshot.push(vars.clone());
+                    idx += 1;
+                }
+
+                _ => idx += 1,
+            }
+        }
+    }
+}
+
+// Replaces %VAR% in a string with values from `vars`
+fn expand_string(input: &str, vars: &HashMap<String, String>) -> String
+{
+    let re = regex::Regex::new(r"%([^%]+)%").unwrap();
+    re.replace_all(input, |caps: &regex::Captures| {
+        vars.get(&caps[1]).cloned().unwrap_or_default()
+    })
+    .into_owned()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod compile;
+mod expand_vars;
 mod parse;
 mod tokenizer;
 
@@ -70,12 +71,16 @@ fn main()
     }
 
     println!("Begin parsing");
-    let statements = parse::parse(tokens);
+    let mut statements = parse::parse(tokens);
     println!("Parsing complete");
     println!("Statements: {}", statements.len());
     for stmt in &statements {
         println!("{:?}", stmt);
     }
+
+    println!("Begin variable expansion");
+    expand_vars::expand_vars(&args.input, &mut statements);
+    println!("Variable expansion complete");
 
     println!("Begin compilation");
     compile::compile(&statements, &args.output, &args.input);
@@ -93,7 +98,9 @@ fn main()
             std::process::exit(1);
         }
         if which("lld-link").is_err() {
-            eprintln!("Error: 'lld-link' not found. Please install LLVM via a package that includes lld-link.");
+            eprintln!(
+                "Error: 'lld-link' not found. Please install LLVM via a package that includes lld-link."
+            );
             std::process::exit(1);
         }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -29,6 +29,12 @@ pub enum Statement
     },
     Label(String),
     Rem(String),
+    Set
+    {
+        variable: Vec<String>,
+        value: String,
+        invisible: bool,
+    },
     RedirectionOverwriteFile(String),
     RedirectionAppendFile(String),
     RedirectionStderrOverwriteFile(String),
@@ -206,6 +212,34 @@ pub fn parse(tokens: Vec<TokenInfo>) -> Vec<Statement>
                 }
                 Statement::Exit {
                     value: args,
+                    invisible,
+                }
+            }
+
+            Token::Set => {
+                let mut args = Vec::new();
+                while let Some(token_info) = iter.peek() {
+                    match &token_info.token {
+                        Token::Identifier(arg) => {
+                            args.push(arg.clone());
+                            iter.next();
+                        }
+                        _ => break,
+                    }
+                }
+                // Split args into variable and value by '=' and store each part in variable and
+                // value
+                let args_str = args.join("");
+                let parts: Vec<&str> = args_str.split('=').collect();
+
+                let variable = parts[0].to_string();
+                // Convert variable to Vec<String>
+                let variable: Vec<String> = variable.split(' ').map(|s| s.to_string()).collect();
+                let value = parts[1].to_string();
+
+                Statement::Set {
+                    variable,
+                    value,
                     invisible,
                 }
             }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -7,8 +7,7 @@ pub enum Token
     Goto,
     Rem,
     Label,
-    VariablePercentSign,
-    VariableDelayedExpansion,
+    Set,
     RedirectionOverwriteFile,
     RedirectionAppendFile,
     RedirectionStderrOverwriteFile,
@@ -157,6 +156,7 @@ pub fn tokenize(input: &str) -> Vec<TokenInfo>
             "goto" => Token::Goto,
             "rem" => Token::Rem,
             "echo." => Token::EchoNewLine,
+            "set" => Token::Set,
             _ => {
                 if let Ok(num) = word.parse::<i32>() {
                     Token::Integer(num)


### PR DESCRIPTION
**Describe the pull request**
To implement this, i added control flow simulation as variables are expanded instead of stored in the actual output executable. Currently, this control flow simulation only supports jumping to labels as other control flows are NOT implemented. I then added the actual expanding in the expand_string function of expand_vars.

**Checklist**
I made sure that...

- [x] All checks pass
- [x] There are no syntax errors
- [x] The PR is mergeable
- [x] I read [CONTRIBUTING.md](https://github.com/benja2998/batch/blob/main/CONTRIBUTING.md) and followed the guidelines

